### PR TITLE
Fixed shebang and syntax declaration

### DIFF
--- a/RNAseq.nf
+++ b/RNAseq.nf
@@ -1,6 +1,4 @@
-#! /usr/bin/env nextflow
-
-// vim: syntax=groovy -*- mode: groovy;-*-
+#!/usr/bin/env nextflow
 
 // Copyright (C) 2017 IARC/WHO
 


### PR DESCRIPTION
Nextflow syntax is now correctly recognised by GitHub and editor such as Atom or VS Code