### PR TITLE
Update RNAseq.nf

### DIFF
--- a/RNAseq.nf
+++ b/RNAseq.nf
@@ -42,8 +42,6 @@ params.sjtrim       = null
 params.recalibration= null
 
 params.cutadapt     = null
-params.sjtrim       = null
-params.recalibration = null
 params.hisat2       = null
 params.help         = null
 


### PR DESCRIPTION
params.sjtrim and params.recalibration were defined 2 times which generates warnings when launching the pipeline